### PR TITLE
pass miner configs to bittensor.axon

### DIFF
--- a/transcription/base/miner.py
+++ b/transcription/base/miner.py
@@ -47,7 +47,7 @@ class BaseMinerNeuron(BaseNeuron):
             )
 
         # The axon handles request processing, allowing validators to send this miner requests.
-        self.axon = bt.axon(wallet=self.wallet, port=self.config.axon.port)
+        self.axon = bt.axon(wallet=self.wallet, config=self.config)
 
         # Attach determiners which functions are called when servicing a request.
         bt.logging.info(f"Attaching forward function to miner axon.")


### PR DESCRIPTION
Ensure bittensor.axon() uses all the configurations for the miner when defined in pm2 start command.

Such as --axon.ip --axon.external_ip

### pm2 command sample:
```
pm2 start ./neurons/miner.py --name MINER --interpreter python3 -- \
  --netuid 11 \
  --subtensor.network local \
  --wallet.name default \
  --wallet.hotkey default \
  --axon.port 50010 \
  --axon.external_port 50010 \
  --axon.ip "87.120.211.55" \
  --axon.external_ip "87.120.211.55" \
  --logging.debug \
  --logging.trace \
  --blacklist.force_validator_permit \
  --batch_size 6 \
  --training_mode normal \
  --device gpu:0
```

### Result in pm2 logs:
![image](https://github.com/Cazure8/transcription-subnet/assets/69808183/717b86fc-e06e-4e3d-8f18-44f8e9b2cccc)
